### PR TITLE
fix Page turning error

### DIFF
--- a/shardingsphere-ui-frontend/src/views/data-scaling/module/index.vue
+++ b/shardingsphere-ui-frontend/src/views/data-scaling/module/index.vue
@@ -597,7 +597,7 @@ export default {
     },
     handleCurrentChange(val) {
       const data = clone(this.cloneTableData)
-      this.tableData = data.splice(val - 1, this.pageSize)
+      this.tableData = data.splice((val - 1) * this.pageSize, this.pageSize)
     },
     getJobList() {
       API.getJobList().then(res => {


### PR DESCRIPTION
### When Data scaling job count more than 10, Page turning will occur error。
#### example:
if job count is 13 ,first page：1-10,second page should 11-13, but actual second page error display 2-11。
![image](https://user-images.githubusercontent.com/12946820/102882168-f0bb9b80-4488-11eb-8eb5-f75660fba573.png)
I have fix it，The correct results is
![image](https://user-images.githubusercontent.com/12946820/102882260-121c8780-4489-11eb-96c1-19a643e9c4ff.png)
